### PR TITLE
Fix scheduler reliability gaps and improve intervention handling

### DIFF
--- a/src/Aura.Orchestrator/Communication/CommandPayloads.cs
+++ b/src/Aura.Orchestrator/Communication/CommandPayloads.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Aura.Orchestrator.Models;
@@ -122,4 +123,22 @@ public sealed class ArtifactData
 
     [JsonProperty("metadata")]
     public JObject Metadata { get; set; } = new();
+}
+
+public sealed class DroneRegistrationPayload
+{
+    [JsonProperty("droneId")]
+    public string DroneId { get; set; } = string.Empty;
+
+    [JsonProperty("version")]
+    public string Version { get; set; } = string.Empty;
+
+    [JsonProperty("staticCapabilities")]
+    public IList<string>? StaticCapabilities { get; set; }
+
+    [JsonProperty("modules")]
+    public IList<string>? Modules { get; set; }
+
+    [JsonProperty("limitsSupported")]
+    public LimitsSupport? LimitsSupported { get; set; }
 }

--- a/src/Aura.Orchestrator/Interventions/EnhancedInterventionManager.cs
+++ b/src/Aura.Orchestrator/Interventions/EnhancedInterventionManager.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -7,6 +9,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Aura.Orchestrator.Metrics;
+using Aura.Orchestrator.Models;
+using Newtonsoft.Json.Linq;
 
 namespace Aura.Orchestrator.Interventions;
 
@@ -22,6 +26,7 @@ public sealed class EnhancedInterventionManager : IInterventionManager
     private readonly SemaphoreSlim _interventionLock = new(1, 1);
     private InterventionContext? _currentIntervention;
     private CancellationTokenSource? _timeoutCts;
+    private CancellationTokenSource? _stepTimeoutCts;
 
     public EnhancedInterventionManager(
         ILogger<EnhancedInterventionManager> logger,
@@ -79,8 +84,11 @@ public sealed class EnhancedInterventionManager : IInterventionManager
                 LastStepTime = DateTime.UtcNow
             };
 
+            CancelWindowTimer();
+            CancelStepTimer();
             _timeoutCts = new CancellationTokenSource(_currentIntervention.WindowTtl);
             _timeoutCts.Token.Register(() => _ = HandleInterventionTimeoutAsync());
+            ResetStepTimer();
 
             _browserController.SetInteractionEnabled(true);
 
@@ -133,6 +141,8 @@ public sealed class EnhancedInterventionManager : IInterventionManager
                 Command = command
             });
 
+            ResetStepTimer();
+
             _logger.LogDebug("Executing intervention command: {CommandType}", command.GetType().Name);
             return await _mediator.Send(command).ConfigureAwait(false);
         }
@@ -154,8 +164,8 @@ public sealed class EnhancedInterventionManager : IInterventionManager
 
             _logger.LogInformation("Resuming execution after intervention");
 
-            _timeoutCts?.Cancel();
-            _timeoutCts = null;
+            CancelWindowTimer();
+            CancelStepTimer();
 
             _browserController.SetInteractionEnabled(false);
 
@@ -206,9 +216,311 @@ public sealed class EnhancedInterventionManager : IInterventionManager
 
     public Task<bool> CheckForInterventionAsync(string url, PersonaOverlay persona)
     {
-        _ = url;
-        _ = persona;
-        return Task.FromResult(false);
+        persona ??= new PersonaOverlay();
+        var requiresIntervention = ShouldTriggerIntervention(url, persona);
+        if (requiresIntervention)
+        {
+            var personaId = string.IsNullOrWhiteSpace(persona.PersonaId) ? "unknown" : persona.PersonaId;
+            _logger.LogInformation("Persona {PersonaId} flagged {Url} for manual intervention", personaId, url);
+            _metricsCollector.IncrementCounter("drone_intervention_candidates", 1, new Dictionary<string, string>
+            {
+                ["persona_id"] = personaId,
+                ["reason"] = "persona_rules"
+            });
+        }
+
+        return Task.FromResult(requiresIntervention);
+    }
+
+    private bool ShouldTriggerIntervention(string url, PersonaOverlay persona)
+    {
+        if (string.IsNullOrWhiteSpace(url) || persona == null || persona.Traits == null)
+        {
+            return false;
+        }
+
+        var traits = persona.Traits;
+        var affirmativeKeys = new[]
+        {
+            "requireIntervention",
+            "requiresIntervention",
+            "alwaysRequireIntervention",
+            "manualReview",
+            "manual_review",
+            "forceIntervention"
+        };
+
+        foreach (var key in affirmativeKeys)
+        {
+            if (traits.TryGetValue(key, out var flag) && TryGetBool(flag))
+            {
+                return true;
+            }
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        var host = uri.Host;
+        var path = uri.AbsolutePath;
+        var fullUrl = uri.ToString();
+
+        if (MatchesTrait(traits, "interventionDomains", host, static (pattern, candidate) => candidate.EndsWith(pattern, StringComparison.OrdinalIgnoreCase)))
+        {
+            return true;
+        }
+
+        if (MatchesTrait(traits, "interventionPaths", path, static (pattern, candidate) => candidate.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0))
+        {
+            return true;
+        }
+
+        if (MatchesTrait(traits, "interventionKeywords", fullUrl, static (pattern, candidate) => candidate.IndexOf(pattern, StringComparison.OrdinalIgnoreCase) >= 0))
+        {
+            return true;
+        }
+
+        if (traits.TryGetValue("interventionRules", out var rules) && EvaluateRuleCollection(rules, host, path, fullUrl))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool MatchesTrait(IDictionary<string, object?> traits, string key, string candidate, Func<string, string, bool> predicate)
+    {
+        if (!traits.TryGetValue(key, out var value))
+        {
+            return false;
+        }
+
+        foreach (var pattern in ExtractStringValues(value))
+        {
+            if (predicate(pattern, candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool EvaluateRuleCollection(object? rules, string host, string path, string fullUrl)
+    {
+        switch (rules)
+        {
+            case null:
+                return false;
+            case string single:
+                return host.EndsWith(single, StringComparison.OrdinalIgnoreCase) ||
+                       path.IndexOf(single, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                       fullUrl.IndexOf(single, StringComparison.OrdinalIgnoreCase) >= 0;
+            case JObject jObject:
+                return EvaluateRuleCollection(jObject.ToObject<Dictionary<string, object?>>() ?? new Dictionary<string, object?>(), host, path, fullUrl);
+            case IDictionary dictionary:
+            {
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    var key = entry.Key?.ToString();
+                    if (string.IsNullOrWhiteSpace(key))
+                    {
+                        continue;
+                    }
+
+                    var values = ExtractStringValues(entry.Value).ToArray();
+                    if (values.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (IsDomainKey(key) && values.Any(value => host.EndsWith(value, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        return true;
+                    }
+
+                    if (IsPathKey(key) && values.Any(value => path.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0))
+                    {
+                        return true;
+                    }
+
+                    if (IsKeywordKey(key) && values.Any(value => fullUrl.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            case IEnumerable enumerable when rules is not string:
+            {
+                foreach (var entry in enumerable)
+                {
+                    if (EvaluateRuleCollection(entry, host, path, fullUrl))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            default:
+                var fallback = rules.ToString();
+                if (string.IsNullOrWhiteSpace(fallback))
+                {
+                    return false;
+                }
+
+                return host.EndsWith(fallback, StringComparison.OrdinalIgnoreCase) ||
+                       path.IndexOf(fallback, StringComparison.OrdinalIgnoreCase) >= 0 ||
+                       fullUrl.IndexOf(fallback, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+    }
+
+    private static bool IsDomainKey(string key) => key.Equals("domain", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("domains", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("host", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("hosts", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsPathKey(string key) => key.Equals("path", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("paths", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsKeywordKey(string key) => key.Equals("keyword", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("keywords", StringComparison.OrdinalIgnoreCase) ||
+        key.Equals("contains", StringComparison.OrdinalIgnoreCase);
+
+    private static IEnumerable<string> ExtractStringValues(object? raw)
+    {
+        switch (raw)
+        {
+            case null:
+                yield break;
+            case string single when !string.IsNullOrWhiteSpace(single):
+                yield return single.Trim();
+                yield break;
+            case JValue jValue when jValue.Type == JTokenType.String:
+                var text = jValue.Value<string>();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    yield return text.Trim();
+                }
+                yield break;
+            case JValue jValue when jValue.Type == JTokenType.Boolean:
+                yield return jValue.Value<bool>().ToString();
+                yield break;
+            case IEnumerable enumerable when raw is not string:
+                foreach (var item in enumerable)
+                {
+                    foreach (var value in ExtractStringValues(item))
+                    {
+                        yield return value;
+                    }
+                }
+                yield break;
+            default:
+                var fallback = raw.ToString();
+                if (!string.IsNullOrWhiteSpace(fallback))
+                {
+                    yield return fallback.Trim();
+                }
+                yield break;
+        }
+    }
+
+    private static bool TryGetBool(object? value) => value switch
+    {
+        null => false,
+        bool b => b,
+        string s when bool.TryParse(s, out var parsed) => parsed,
+        JValue jValue when jValue.Type == JTokenType.Boolean => jValue.Value<bool>(),
+        JValue jValue when jValue.Type == JTokenType.Integer => jValue.Value<long>() != 0,
+        _ => false
+    };
+
+    private void ResetStepTimer()
+    {
+        CancelStepTimer();
+
+        if (_currentIntervention == null)
+        {
+            return;
+        }
+
+        if (_currentIntervention.StepTtl <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        var stepCts = new CancellationTokenSource();
+        _stepTimeoutCts = stepCts;
+        stepCts.CancelAfter(_currentIntervention.StepTtl);
+        stepCts.Token.Register(() => _ = HandleStepTimeoutAsync());
+    }
+
+    private void CancelStepTimer()
+    {
+        var existing = Interlocked.Exchange(ref _stepTimeoutCts, null);
+        if (existing != null)
+        {
+            try
+            {
+                existing.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed.
+            }
+            existing.Dispose();
+        }
+    }
+
+    private void CancelWindowTimer()
+    {
+        var existing = Interlocked.Exchange(ref _timeoutCts, null);
+        if (existing != null)
+        {
+            try
+            {
+                existing.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed.
+            }
+            existing.Dispose();
+        }
+    }
+
+    private Task HandleStepTimeoutAsync()
+    {
+        _logger.LogWarning("Intervention step timeout for command {CommandId}", _currentIntervention?.CommandId);
+        return Task.Run(async () =>
+        {
+            await _interventionLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (_currentIntervention != null)
+                {
+                    var elapsed = DateTime.UtcNow - _currentIntervention.LastStepTime;
+                    if (_currentIntervention.StepTtl > TimeSpan.Zero && elapsed >= _currentIntervention.StepTtl)
+                    {
+                        var commandId = _currentIntervention.CommandId;
+                        _currentIntervention = null;
+                        CancelWindowTimer();
+                        CancelStepTimer();
+                        _browserController.SetInteractionEnabled(false);
+                        _metricsCollector.IncrementCounter("drone_intervention_step_timeouts", 1);
+                        _logger.LogWarning("Intervention cancelled due to step TTL for command {CommandId}", commandId);
+                    }
+                }
+            }
+            finally
+            {
+                _interventionLock.Release();
+            }
+        });
     }
 
     private static bool IsAllowedInterventionCommand(IDroneCommand command) => command switch
@@ -271,9 +583,13 @@ public sealed class EnhancedInterventionManager : IInterventionManager
             {
                 if (_currentIntervention != null)
                 {
+                    var timedOutCommand = _currentIntervention.CommandId;
                     _currentIntervention = null;
+                    CancelStepTimer();
+                    CancelWindowTimer();
                     _browserController.SetInteractionEnabled(false);
                     _metricsCollector.IncrementCounter("drone_intervention_timeouts", 1);
+                    _logger.LogWarning("Intervention timed out after window TTL for command {CommandId}", timedOutCommand);
                 }
             }
             finally

--- a/src/Aura.Orchestrator/Services/ICommandLifecycleTracker.cs
+++ b/src/Aura.Orchestrator/Services/ICommandLifecycleTracker.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Aura.Orchestrator.Security;
 
 namespace Aura.Orchestrator.Services;
 
@@ -6,7 +7,7 @@ public interface ICommandLifecycleTracker
 {
     CommandDispatchRegistration RegisterDispatch(string commandId, string droneId, SemaphoreSlim pacingToken, DomainLease? domainLease);
 
-    Task<bool> WaitForAcknowledgementAsync(string commandId, TimeSpan timeout, CancellationToken cancellationToken);
+    Task<CommandAcknowledgementResult> WaitForAcknowledgementAsync(string commandId, TimeSpan timeout, CancellationToken cancellationToken);
 
     void MarkAcknowledged(string commandId, string droneId);
 
@@ -18,3 +19,16 @@ public interface ICommandLifecycleTracker
 }
 
 public sealed record CommandDispatchRegistration(string CommandId, string DroneId);
+
+public enum CommandAcknowledgementStatus
+{
+    Acknowledged,
+    Failed,
+    Timeout
+}
+
+public sealed record CommandAcknowledgementResult(CommandAcknowledgementStatus Status, string? FailureReason = null)
+{
+    public static CommandAcknowledgementResult Acknowledged { get; } = new(CommandAcknowledgementStatus.Acknowledged);
+    public static CommandAcknowledgementResult Timeout { get; } = new(CommandAcknowledgementStatus.Timeout);
+}


### PR DESCRIPTION
## Summary
- add the missing `DroneRegistrationPayload` contract
- make the domain limiter’s burst counter decay over time instead of blocking forever
- rework the task scheduler to avoid dropping queue entries, update last-assignment tracking, and requeue commands that time out or lose their drone
- enrich the command lifecycle tracker with acknowledgement outcomes to drive the new scheduler behaviour
- implement persona-based intervention detection and enforce step TTL timeouts while tightening the human-like automation helpers

## Testing
- `dotnet build src/Aura.Orchestrator/Aura.Orchestrator.csproj` *(fails: dotnet SDK is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca32b0591883208c34e8dc2bbde0f6