### PR TITLE
Improve scheduler resilience and intervention notifications

### DIFF
--- a/scripts/humanLikeActions.js
+++ b/scripts/humanLikeActions.js
@@ -55,15 +55,24 @@ export async function humanLikeType(selector, text, profile = {}) {
   let totalDelay = 0;
   let typedCount = 0;
   for (const char of text) {
-    if ('value' in element) {
-      element.value += char;
-    } else {
-      element.textContent = (element.textContent || '') + char;
+    const keyEventInit = { key: char, bubbles: true };
+    element.dispatchEvent(new KeyboardEvent('keydown', keyEventInit));
+
+    if (char.length === 1) {
+      element.dispatchEvent(new KeyboardEvent('keypress', keyEventInit));
     }
 
-    element.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
-    element.dispatchEvent(new Event('input', { bubbles: true }));
-    element.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
+    if ('value' in element) {
+      element.value = `${element.value}${char}`;
+    } else {
+      element.textContent = `${element.textContent || ''}${char}`;
+    }
+
+    const inputEvent = typeof InputEvent === 'function'
+      ? new InputEvent('input', { bubbles: true, data: char })
+      : new Event('input', { bubbles: true });
+    element.dispatchEvent(inputEvent);
+    element.dispatchEvent(new KeyboardEvent('keyup', keyEventInit));
 
     const rawDelay = randomDelay(options.charDelayMs, options.varianceMs);
     const delay = Math.max(0, Math.min(rawDelay, options.maxDelayMs));

--- a/src/Aura.Orchestrator/Communication/DroneHub.cs
+++ b/src/Aura.Orchestrator/Communication/DroneHub.cs
@@ -103,6 +103,12 @@ public sealed class DroneHub : Hub
         _logger.LogInformation("Drone {DroneId} registered successfully", payload.DroneId);
     }
 
+    public Task RegisterOperator()
+    {
+        _logger.LogInformation("Operator connection {ConnectionId} registered", Context.ConnectionId);
+        return Groups.AddToGroupAsync(Context.ConnectionId, "operators");
+    }
+
     public async Task AcknowledgeCommand(string commandId)
     {
         var droneId = _droneRegistry.GetDroneIdByConnection(Context.ConnectionId);

--- a/src/Aura.Orchestrator/Configuration/OrchestratorConfig.cs
+++ b/src/Aura.Orchestrator/Configuration/OrchestratorConfig.cs
@@ -39,6 +39,11 @@ public sealed class SchedulingConfig
     /// Sleep interval between per drone queue scans.
     /// </summary>
     public int DispatchLoopDelayMs { get; set; } = 100;
+
+    /// <summary>
+    /// Maximum number of persona lookup retries before abandoning a task.
+    /// </summary>
+    public int MaxPersonaLookupRetries { get; set; } = 3;
 }
 
 public sealed class ReadyQueueConfig

--- a/src/Aura.Orchestrator/Interventions/IInterventionEventPublisher.cs
+++ b/src/Aura.Orchestrator/Interventions/IInterventionEventPublisher.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Aura.Orchestrator.Interventions;
+
+public interface IInterventionEventPublisher
+{
+    Task PublishAsync(InterventionRequiredEvent @event, CancellationToken cancellationToken = default);
+}
+
+public sealed record InterventionRequiredEvent(
+    string CommandId,
+    string ParentCommandId,
+    string Reason,
+    bool Resumable,
+    string? Url,
+    IReadOnlyDictionary<string, object?> Context,
+    string? ScreenshotPath);

--- a/src/Aura.Orchestrator/Interventions/SignalRInterventionEventPublisher.cs
+++ b/src/Aura.Orchestrator/Interventions/SignalRInterventionEventPublisher.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Aura.Orchestrator.Communication;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace Aura.Orchestrator.Interventions;
+
+public sealed class SignalRInterventionEventPublisher : IInterventionEventPublisher
+{
+    private readonly IHubContext<DroneHub> _hubContext;
+    private readonly ILogger<SignalRInterventionEventPublisher> _logger;
+
+    public SignalRInterventionEventPublisher(
+        IHubContext<DroneHub> hubContext,
+        ILogger<SignalRInterventionEventPublisher> logger)
+    {
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    public Task PublishAsync(InterventionRequiredEvent @event, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Broadcasting intervention event for command {CommandId}", @event.CommandId);
+        return _hubContext
+            .Clients
+            .Group("operators")
+            .SendAsync("RequireIntervention", @event, cancellationToken);
+    }
+}

--- a/src/Aura.Orchestrator/Scheduling/ScheduledTask.cs
+++ b/src/Aura.Orchestrator/Scheduling/ScheduledTask.cs
@@ -17,6 +17,7 @@ public sealed class ScheduledTask
     public DateTime EnqueuedAt { get; set; } = DateTime.UtcNow;
     public string NodeId { get; set; } = string.Empty;
     public string ProcessId { get; set; } = string.Empty;
+    public int PersonaLookupFailures { get; set; }
 }
 
 public enum TaskPriority

--- a/src/Aura.Orchestrator/Security/PublicSuffixList.cs
+++ b/src/Aura.Orchestrator/Security/PublicSuffixList.cs
@@ -61,7 +61,15 @@ public sealed class PublicSuffixList
         }
 
         var idn = new IdnMapping();
-        var asciiHost = idn.GetAscii(host);
+        string asciiHost;
+        try
+        {
+            asciiHost = idn.GetAscii(host);
+        }
+        catch (ArgumentException)
+        {
+            return host.ToLowerInvariant();
+        }
         var labels = asciiHost.Split('.', StringSplitOptions.RemoveEmptyEntries);
         if (labels.Length == 0)
         {

--- a/src/Aura.Orchestrator/Services/CommandLifecycleTracker.cs
+++ b/src/Aura.Orchestrator/Services/CommandLifecycleTracker.cs
@@ -113,6 +113,17 @@ public sealed class CommandLifecycleTracker : ICommandLifecycleTracker
         }
     }
 
+    public void RecordFailure(string commandId, string reason)
+    {
+        if (_states.TryRemove(commandId, out var state))
+        {
+            state.MarkFailed(reason);
+            state.ReleaseResources();
+        }
+
+        _completionResults[commandId] = new CommandAcknowledgementResult(CommandAcknowledgementStatus.Failed, reason);
+    }
+
     private sealed class CommandState
     {
         private readonly TaskCompletionSource<CommandAcknowledgementResult> _acknowledged = new(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/Aura.Orchestrator/Services/ICommandLifecycleTracker.cs
+++ b/src/Aura.Orchestrator/Services/ICommandLifecycleTracker.cs
@@ -16,6 +16,8 @@ public interface ICommandLifecycleTracker
     void Fail(string commandId, string droneId, string reason);
 
     void FailAll(string droneId, string reason);
+
+    void RecordFailure(string commandId, string reason);
 }
 
 public sealed record CommandDispatchRegistration(string CommandId, string DroneId);


### PR DESCRIPTION
## Summary
- prevent persona lookup failures from dropping commands by retrying a limited number of times and recording final failure metrics
- harden domain limiting and public suffix logic plus align human typing simulation with native event ordering
- publish intervention events through SignalR so operator clients can subscribe via the hub

## Testing
- dotnet --version *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3e38a0448320b3dd117857ff1968