### PR TITLE
Improve scheduler resilience and detection heuristics

### DIFF
--- a/scripts/detectCaptcha.js
+++ b/scripts/detectCaptcha.js
@@ -1,27 +1,124 @@
-export function detectCaptcha() {
-  const selectors = [
-    'iframe[src*="recaptcha" i]',
-    'iframe[src*="hcaptcha" i]',
-    'iframe[src*="captcha" i]',
-    '[class*="captcha" i]',
-    '[id*="captcha" i]'
-  ];
+import {
+  collectEvidence,
+  computeOverlayScore,
+  elementContainsText,
+  extractTextTokens,
+  gatherCandidates,
+  getElementRole,
+  isVisible,
+  queryDeep
+} from './utils/dom.js';
 
-  for (const selector of selectors) {
-    const element = document.querySelector(selector);
-    if (element && isVisible(element)) {
-      return {
-        detected: true,
-        reason: 'captcha',
-        evidence: selector
-      };
+const FRAME_SELECTORS = [
+  'iframe[src*="recaptcha" i]',
+  'iframe[src*="hcaptcha" i]',
+  'iframe[src*="turnstile" i]',
+  'iframe[src*="captcha" i]'
+];
+
+const KEYWORD_PATTERNS = [
+  /captcha/i,
+  /robot/i,
+  /select all images/i,
+  /verify you/i,
+  /security check/i
+];
+
+const TOKEN_SELECTORS = [
+  '[data-sitekey]',
+  'div[id*="captcha" i]',
+  'div[class*="captcha" i]'
+];
+
+const BADGE_SELECTORS = [
+  '.grecaptcha-badge',
+  '.hcaptcha-badge',
+  '[class*="-captcha-badge" i]'
+];
+
+const SCRIPT_HINTS = [/recaptcha/i, /hcaptcha/i, /turnstile/i, /captchaService/i];
+
+const ACCESSIBLE_HINTS = [/captcha/i, /are you human/i, /security challenge/i];
+
+export function detectCaptcha() {
+  const matchedElements = [];
+  const visited = new Set();
+  let score = 0;
+
+  const track = (element, weight) => {
+    if (!element || visited.has(element) || !isVisible(element)) {
+      return;
+    }
+    visited.add(element);
+    matchedElements.push(element);
+    score += weight;
+  };
+
+  FRAME_SELECTORS.forEach(selector => {
+    document.querySelectorAll(selector).forEach(el => track(el, 0.5));
+  });
+
+  TOKEN_SELECTORS.forEach(selector => {
+    document.querySelectorAll(selector).forEach(el => track(el, 0.25));
+  });
+
+  const keywordContainers = Array.from(document.querySelectorAll('div, span, label, p, button'))
+    .concat(queryDeep('div, span, label, p, button'))
+    .filter(el => isVisible(el) && elementContainsText(el, KEYWORD_PATTERNS));
+  keywordContainers.forEach(el => track(el, 0.15));
+
+  gatherCandidates(BADGE_SELECTORS).forEach(el => track(el, 0.2));
+
+  const overlayCandidates = gatherCandidates(['[role="dialog"]', '[class*="modal" i]', '[class*="overlay" i]']);
+  overlayCandidates
+    .map(el => ({ el, overlayScore: computeOverlayScore(el) }))
+    .filter(({ overlayScore }) => overlayScore >= 0.2)
+    .forEach(({ el, overlayScore }) => track(el, Math.min(0.25, overlayScore)));
+
+  const scripts = Array.from(document.scripts || []);
+  if (scripts.some(script => SCRIPT_HINTS.some(pattern => pattern.test(script.src || script.text || '')))) {
+    score += 0.15;
+  }
+
+  const accessibleHints = gatherCandidates(['[aria-label]', '[aria-describedby]', '[aria-labelledby]'])
+    .filter(el => ACCESSIBLE_HINTS.some(pattern => pattern.test((el.getAttribute('aria-label') || '').toLowerCase())));
+  accessibleHints.forEach(el => track(el, 0.1));
+
+  const interactiveTokens = gatherCandidates(['button', 'input[type="button"]', 'input[type="submit"]'])
+    .filter(el => {
+      const tokens = extractTextTokens(el);
+      return tokens.includes('captcha') || tokens.includes('verify');
+    });
+  interactiveTokens.forEach(el => track(el, 0.1));
+
+  if (window.grecaptcha || window.hcaptcha) {
+    score += 0.2;
+  }
+
+  if (document.body) {
+    const bodyStyle = window.getComputedStyle(document.body);
+    if (bodyStyle.filter && bodyStyle.filter.includes('blur')) {
+      score += 0.1;
     }
   }
 
-  return { detected: false };
+  const confidence = Math.min(1, score + matchedElements.reduce((acc, el) => acc + computeOverlayScore(el), 0) * 0.3);
+  return {
+    detected: confidence >= 0.55,
+    confidence: Number(confidence.toFixed(2)),
+    reason: inferReason(matchedElements),
+    evidence: collectEvidence(matchedElements)
+  };
 }
 
-function isVisible(element) {
-  const rect = element.getBoundingClientRect();
-  return rect.width > 0 && rect.height > 0 && window.getComputedStyle(element).visibility !== 'hidden';
+function inferReason(elements) {
+  if (elements.some(el => getElementRole(el) === 'dialog')) {
+    return 'captcha_dialog';
+  }
+
+  if (elements.some(el => el.tagName && el.tagName.toLowerCase() === 'iframe')) {
+    return 'captcha_iframe';
+  }
+
+  return 'captcha';
 }

--- a/scripts/detectConsent.js
+++ b/scripts/detectConsent.js
@@ -1,29 +1,103 @@
-function elementContainsText(element, patterns) {
-  const text = (element.textContent || '').trim();
-  return patterns.some(pattern => pattern.test(text));
-}
+import {
+  collectEvidence,
+  computeOverlayScore,
+  elementContainsText,
+  extractTextTokens,
+  gatherCandidates,
+  getVisibilityMetrics,
+  isVisible
+} from './utils/dom.js';
+
+const CONSENT_SELECTORS = [
+  '[class*="consent" i]',
+  '[class*="cookie" i]',
+  '[id*="consent" i]',
+  '[id*="cookie" i]',
+  '[aria-label*="consent" i]'
+];
+
+const ACTION_PATTERNS = [
+  /accept/i,
+  /agree/i,
+  /allow/i,
+  /preferences/i,
+  /manage/i
+];
+
+const EXPLANATION_PATTERNS = [
+  /we use cookies/i,
+  /privacy/i,
+  /consent/i,
+  /personalise/i
+];
+
+const VENDOR_PATTERNS = [/iab/i, /one\strust/i, /trustarc/i, /cookiebot/i];
+
+const BLOCKING_SELECTORS = ['[data-testid*="consent" i]', '[class*="banner" i]', '[id*="gdpr" i]'];
 
 export function detectConsent() {
-  const containers = Array.from(document.querySelectorAll('[class*="consent" i], [class*="cookie" i], [id*="consent" i], [id*="cookie" i]'))
-    .filter(isVisible)
-    .filter(el => el.getBoundingClientRect().height > 40);
+  const matchedElements = [];
+  const visited = new Set();
+  let score = 0;
 
-  const actionButtons = Array.from(document.querySelectorAll('button, a, input[type="submit"]'))
-    .filter(isVisible)
-    .filter(el => elementContainsText(el, [/accept/i, /agree/i, /consent/i]));
+  const track = (element, weight) => {
+    if (!element || visited.has(element) || !isVisible(element)) {
+      return;
+    }
+    visited.add(element);
+    matchedElements.push(element);
+    score += weight;
+  };
 
-  if (containers.length > 0 && actionButtons.length > 0) {
-    return {
-      detected: true,
-      reason: 'consent_wall',
-      evidence: 'consent_container'
-    };
+  CONSENT_SELECTORS.forEach(selector => {
+    document.querySelectorAll(selector).forEach(el => track(el, 0.3));
+  });
+
+  const visibleButtons = Array.from(document.querySelectorAll('button, a, input[type="button"], input[type="submit"]'))
+    .concat(gatherCandidates(['button', 'a', 'input[type="button"]', 'input[type="submit"]']))
+    .filter(el => isVisible(el) && (elementContainsText(el, ACTION_PATTERNS) || hasActionTokens(el)));
+  visibleButtons.forEach(el => track(el, 0.25));
+
+  const explanatoryCopy = Array.from(document.querySelectorAll('div, p, span'))
+    .concat(gatherCandidates(['div', 'p', 'span']))
+    .filter(el => isVisible(el) && elementContainsText(el, EXPLANATION_PATTERNS));
+  explanatoryCopy.forEach(el => track(el, 0.15));
+
+  const overlays = Array.from(document.querySelectorAll('[role="dialog"], [class*="modal" i], [class*="banner" i]'))
+    .concat(gatherCandidates(BLOCKING_SELECTORS))
+    .filter(isVisible)
+    .map(el => ({ el, metrics: getVisibilityMetrics(el), overlayScore: computeOverlayScore(el) }));
+  overlays
+    .filter(({ metrics }) => metrics.areaRatio >= 0.08)
+    .forEach(({ el, overlayScore }) => track(el, Math.min(0.25, overlayScore + 0.15)));
+
+  if (document.body) {
+    const bodyStyle = window.getComputedStyle(document.body);
+    if (bodyStyle.overflow === 'hidden') {
+      score += 0.1;
+    }
   }
 
-  return { detected: false };
+  if (document.cookie && /consent/.test(document.cookie)) {
+    score += 0.05;
+  }
+
+  const vendorScripts = Array.from(document.scripts || [])
+    .filter(script => VENDOR_PATTERNS.some(pattern => pattern.test(script.src || script.text || '')));
+  if (vendorScripts.length > 0) {
+    score += 0.1;
+  }
+
+  const confidence = Math.min(1, score + overlays.reduce((acc, { overlayScore }) => acc + overlayScore, 0) * 0.3);
+  return {
+    detected: confidence >= 0.5,
+    confidence: Number(confidence.toFixed(2)),
+    reason: 'consent_wall',
+    evidence: collectEvidence(matchedElements)
+  };
 }
 
-function isVisible(element) {
-  const rect = element.getBoundingClientRect();
-  return rect.width > 0 && rect.height > 0 && window.getComputedStyle(element).visibility !== 'hidden';
+function hasActionTokens(element) {
+  const tokens = extractTextTokens(element);
+  return tokens.includes('accept') || tokens.includes('agree') || tokens.includes('reject') || tokens.includes('consent');
 }

--- a/scripts/detectLoginWall.js
+++ b/scripts/detectLoginWall.js
@@ -1,38 +1,89 @@
-export function detectLoginWall() {
-  const selectors = [
-    'input[type="password"]',
-    'form[action*="login" i]',
-    'form[action*="signin" i]',
-    'form[action*="auth" i]'
-  ];
+import {
+  collectEvidence,
+  computeOverlayScore,
+  elementContainsText,
+  extractTextTokens,
+  gatherCandidates,
+  getVisibilityMetrics,
+  isVisible
+} from './utils/dom.js';
 
-  for (const selector of selectors) {
-    const element = document.querySelector(selector);
-    if (element && isVisible(element)) {
-      return {
-        detected: true,
-        reason: 'login_wall',
-        evidence: selector
-      };
+const AUTH_SELECTORS = [
+  'form[action*="login" i]',
+  'form[action*="signin" i]',
+  'form[action*="auth" i]',
+  'div[class*="login" i]',
+  'div[id*="login" i]'
+];
+
+const KEYWORD_PATTERNS = [
+  /sign\s?in/i,
+  /log\s?in/i,
+  /welcome\sback/i,
+  /continue/i
+];
+
+const ENFORCED_SELECTORS = ['[data-test*="login" i]', '[class*="wall" i]', '[class*="paywall" i]'];
+
+const SCRIPT_HINTS = [/authwall/i, /paywall/i, /loginwall/i];
+
+export function detectLoginWall() {
+  const matchedElements = [];
+  const visited = new Set();
+  let score = 0;
+
+  const track = (element, weight) => {
+    if (!element || visited.has(element) || !isVisible(element)) {
+      return;
     }
-  }
+    visited.add(element);
+    matchedElements.push(element);
+    score += weight;
+  };
+
+  AUTH_SELECTORS.forEach(selector => {
+    document.querySelectorAll(selector).forEach(el => track(el, 0.4));
+  });
+
+  gatherCandidates(ENFORCED_SELECTORS).forEach(el => track(el, 0.2));
+
+  const passwordInputs = gatherCandidates(['input[type="password"]', 'input[type="email"]'])
+    .filter(isVisible);
+  passwordInputs.forEach(el => track(el, 0.35));
 
   const keywordButtons = Array.from(document.querySelectorAll('button, a, input[type="submit"]'))
-    .filter(el => isVisible(el))
-    .filter(el => /sign\s?in|log\s?in/i.test(el.textContent || el.value || ''));
+    .concat(gatherCandidates(['button', 'a', 'input[type="submit"]']))
+    .filter(el => isVisible(el) && (elementContainsText(el, KEYWORD_PATTERNS) || hasLoginTokens(el)));
+  keywordButtons.forEach(el => track(el, 0.2));
 
-  if (keywordButtons.length > 0) {
-    return {
-      detected: true,
-      reason: 'login_wall',
-      evidence: 'keyword_button'
-    };
+  const overlays = Array.from(document.querySelectorAll('[class*="modal" i], [class*="overlay" i], div[role="dialog"]'))
+    .concat(gatherCandidates(['[data-testid*="login" i]']))
+    .filter(isVisible)
+    .map(el => ({ el, metrics: getVisibilityMetrics(el), overlayScore: computeOverlayScore(el) }));
+  overlays
+    .filter(({ metrics }) => metrics.areaRatio >= 0.18)
+    .forEach(({ el, overlayScore }) => track(el, Math.min(0.35, overlayScore + 0.2)));
+
+  if (document.body && window.getComputedStyle(document.body).overflow === 'hidden') {
+    score += 0.1;
   }
 
-  return { detected: false };
+  const scriptHints = Array.from(document.scripts || [])
+    .some(script => SCRIPT_HINTS.some(pattern => pattern.test(script.src || script.text || '')));
+  if (scriptHints) {
+    score += 0.1;
+  }
+
+  const confidence = Math.min(1, score);
+  return {
+    detected: confidence >= 0.6,
+    confidence: Number(confidence.toFixed(2)),
+    reason: 'login_wall',
+    evidence: collectEvidence(matchedElements)
+  };
 }
 
-function isVisible(element) {
-  const rect = element.getBoundingClientRect();
-  return rect.width > 0 && rect.height > 0 && window.getComputedStyle(element).visibility !== 'hidden';
+function hasLoginTokens(element) {
+  const tokens = extractTextTokens(element);
+  return tokens.includes('signin') || tokens.includes('login') || tokens.includes('subscribe');
 }

--- a/scripts/humanLikeActions.js
+++ b/scripts/humanLikeActions.js
@@ -1,13 +1,30 @@
+const personaProfiles = new Map();
+
 const defaultTypingProfile = {
   clearFirst: false,
   charDelayMs: 120,
   varianceMs: 45,
-  maxDelayMs: 4000
+  maxDelayMs: 4000,
+  breathEvery: 12,
+  breathDelayMs: 420,
+  errorRate: 0.015,
+  correctionDelayMs: 180
 };
 
 const defaultClickProfile = {
   preMoveDelayMs: 150,
-  hoverMs: 120
+  hoverMs: 120,
+  pressDurationMs: 60,
+  releaseDelayMs: 80,
+  pointerSteps: 10,
+  pointerJitterPx: 6,
+  pointerDurationMs: 220,
+  pointerVarianceMs: 80,
+  targetXRatio: 0.5,
+  targetYRatio: 0.5,
+  targetVariancePx: 6,
+  microAdjustments: 2,
+  scrollAlignment: 'center'
 };
 
 const defaultScrollProfile = {
@@ -15,13 +32,24 @@ const defaultScrollProfile = {
   chunkPx: 280,
   chunks: 3,
   delayMs: 180,
-  varianceMs: 60
+  varianceMs: 60,
+  stepCount: 8,
+  stepDelayMs: 16
 };
 
 const defaultMouseProfile = {
   enable: true,
-  hoverMs: 120,
-  steps: 5
+  steps: 12,
+  jitterPx: 6,
+  durationMs: 240,
+  varianceMs: 90
+};
+
+const pointerState = {
+  pointerId: 1,
+  x: window.innerWidth / 2,
+  y: window.innerHeight / 2,
+  lastTarget: null
 };
 
 function wait(ms) {
@@ -29,21 +57,201 @@ function wait(ms) {
 }
 
 function randomDelay(base, variance) {
-  const delta = (Math.random() - 0.5) * 2 * variance;
-  return Math.max(10, base + delta);
+  const jitter = (Math.random() - 0.5) * 2 * (variance ?? base * 0.35);
+  return Math.max(8, base + jitter);
+}
+
+function easeInOutQuad(t) {
+  return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+}
+
+function getKeyCodeForChar(char) {
+  if (/^[a-z]$/i.test(char)) {
+    return `Key${char.toUpperCase()}`;
+  }
+
+  if (/^[0-9]$/.test(char)) {
+    return `Digit${char}`;
+  }
+
+  if (char === ' ') {
+    return 'Space';
+  }
+
+  return undefined;
+}
+
+function dispatchPointerEvent(target, type, x, y, options = {}) {
+  const eventInit = {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+    pointerId: pointerState.pointerId,
+    pointerType: 'mouse',
+    isPrimary: true,
+    clientX: x,
+    clientY: y,
+    buttons: options.buttons ?? 0,
+    pressure: options.pressure ?? (type === 'pointerdown' ? 0.5 : 0),
+    ...options
+  };
+
+  const pointerEvent = new PointerEvent(type, eventInit);
+  target.dispatchEvent(pointerEvent);
+
+  const mouseTypeMap = {
+    pointerover: 'mouseover',
+    pointerenter: 'mouseenter',
+    pointermove: 'mousemove',
+    pointerdown: 'mousedown',
+    pointerup: 'mouseup',
+    pointerout: 'mouseout',
+    pointerleave: 'mouseleave'
+  };
+
+  const mouseType = mouseTypeMap[type];
+  if (mouseType) {
+    const mouseEvent = new MouseEvent(mouseType, eventInit);
+    target.dispatchEvent(mouseEvent);
+  }
+}
+
+function dispatchPointerFrame(type, x, y, options = {}, explicitTarget) {
+  const target = explicitTarget || document.elementFromPoint(x, y) || document.body || document.documentElement;
+  dispatchPointerEvent(target, type, x, y, options);
+  pointerState.lastTarget = target;
+}
+
+async function smoothPointerMove(targetX, targetY, options) {
+  const steps = Math.max(2, Math.floor(options.steps ?? defaultMouseProfile.steps));
+  const jitterPx = options.jitterPx ?? defaultMouseProfile.jitterPx;
+  const durationMs = options.durationMs ?? defaultMouseProfile.durationMs;
+  const varianceMs = options.varianceMs ?? defaultMouseProfile.varianceMs;
+
+  const startX = pointerState.x;
+  const startY = pointerState.y;
+  const controlX = startX + (targetX - startX) * (0.3 + Math.random() * 0.4) + (Math.random() - 0.5) * jitterPx * 2;
+  const controlY = startY + (targetY - startY) * (0.3 + Math.random() * 0.4) + (Math.random() - 0.5) * jitterPx * 2;
+
+  for (let i = 1; i <= steps; i += 1) {
+    const progress = i / steps;
+    const eased = easeInOutQuad(progress);
+    const bezierT = eased;
+    const deltaX = (1 - bezierT) * (1 - bezierT) * startX +
+      2 * (1 - bezierT) * bezierT * controlX +
+      bezierT * bezierT * targetX +
+      (Math.random() - 0.5) * jitterPx;
+    const deltaY = (1 - bezierT) * (1 - bezierT) * startY +
+      2 * (1 - bezierT) * bezierT * controlY +
+      bezierT * bezierT * targetY +
+      (Math.random() - 0.5) * jitterPx;
+
+    pointerState.x = deltaX;
+    pointerState.y = deltaY;
+    dispatchPointerFrame('pointermove', pointerState.x, pointerState.y, { pressure: 0.05 });
+    dispatchPointerFrame('pointerrawupdate', pointerState.x, pointerState.y, { pressure: 0.04 });
+
+    const delay = randomDelay(durationMs / steps, varianceMs / steps);
+    await wait(delay);
+  }
+}
+
+function applyValueInsertion(element, char) {
+  if ('value' in element) {
+    const input = element;
+    const currentValue = input.value ?? '';
+    const selectionStart = input.selectionStart ?? currentValue.length;
+    const selectionEnd = input.selectionEnd ?? currentValue.length;
+    const before = currentValue.slice(0, selectionStart);
+    const after = currentValue.slice(selectionEnd);
+    input.value = `${before}${char}${after}`;
+    const newCaret = selectionStart + char.length;
+    try {
+      input.selectionStart = input.selectionEnd = newCaret;
+    } catch (_) {
+      // ignore selection errors for non-text inputs
+    }
+  } else {
+    element.textContent = (element.textContent || '') + char;
+  }
+}
+
+async function simulateBackspace(element, options) {
+  const keyOptions = { key: 'Backspace', code: 'Backspace', bubbles: true, cancelable: true };
+  element.dispatchEvent(new KeyboardEvent('keydown', keyOptions));
+
+  if ('value' in element) {
+    const input = element;
+    const value = input.value ?? '';
+    const selectionStart = input.selectionStart ?? value.length;
+    const selectionEnd = input.selectionEnd ?? value.length;
+
+    if (selectionStart === selectionEnd && selectionStart > 0) {
+      const before = value.slice(0, selectionStart - 1);
+      const after = value.slice(selectionEnd);
+      input.value = `${before}${after}`;
+      try {
+        input.selectionStart = input.selectionEnd = selectionStart - 1;
+      } catch (_) {
+        // ignore selection errors
+      }
+    }
+  } else {
+    const text = element.textContent || '';
+    element.textContent = text.slice(0, -1);
+  }
+
+  if (typeof InputEvent === 'function') {
+    element.dispatchEvent(new InputEvent('input', { inputType: 'deleteContentBackward', data: null, bubbles: true }));
+  } else {
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  element.dispatchEvent(new KeyboardEvent('keyup', keyOptions));
+  await wait(options.correctionDelayMs ?? 150);
+}
+
+function randomMistypeCharacter(sourceChar) {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz';
+  const index = Math.max(0, alphabet.indexOf(sourceChar.toLowerCase()));
+  const offset = Math.random() < 0.5 ? -1 : 1;
+  const candidate = alphabet[(index + offset + alphabet.length) % alphabet.length];
+  return sourceChar === sourceChar.toUpperCase() ? candidate.toUpperCase() : candidate;
+}
+
+export function registerPersonaProfile(personaId, profile = {}) {
+  if (!personaId) {
+    return;
+  }
+
+  const normalized = {
+    typing: profile.typing || {},
+    click: profile.click || {},
+    scroll: profile.scroll || {},
+    mouse: profile.mouse || {}
+  };
+
+  personaProfiles.set(String(personaId), normalized);
 }
 
 export async function humanLikeType(selector, text, profile = {}) {
-  const options = { ...defaultTypingProfile, ...profile };
+  const { persona, personaId, ...inlineOverrides } = profile || {};
+  const personaKey = personaId || persona;
+  const personaOverrides = personaKey ? personaProfiles.get(String(personaKey))?.typing : undefined;
+  const options = mergeProfiles(defaultTypingProfile, personaOverrides, inlineOverrides);
   const element = document.querySelector(selector);
   if (!element) {
     throw new Error(`Element not found: ${selector}`);
   }
 
   element.focus();
-  element.dispatchEvent(new Event('focus', { bubbles: true }));
+  element.dispatchEvent(new FocusEvent('focus', { bubbles: true, relatedTarget: document.activeElement }));
+  element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: document.activeElement }));
 
   if (options.clearFirst) {
+    if (typeof InputEvent === 'function') {
+      element.dispatchEvent(new InputEvent('beforeinput', { inputType: 'deleteByCommand', bubbles: true, cancelable: true }));
+    }
     if ('value' in element) {
       element.value = '';
     } else {
@@ -52,90 +260,198 @@ export async function humanLikeType(selector, text, profile = {}) {
     element.dispatchEvent(new Event('input', { bubbles: true }));
   }
 
-  let totalDelay = 0;
   let typedCount = 0;
+  let totalDelay = 0;
+
   for (const char of text) {
-    if ('value' in element) {
-      element.value += char;
-    } else {
-      element.textContent = (element.textContent || '') + char;
+    const sequence = [];
+    const shouldMistype = options.errorRate > 0 && Math.random() < options.errorRate;
+    if (shouldMistype) {
+      sequence.push({ char: randomMistypeCharacter(char), countsTowardsTotal: false });
+    }
+    sequence.push({ char, countsTowardsTotal: true });
+
+    for (let i = 0; i < sequence.length; i += 1) {
+      const { char: currentChar, countsTowardsTotal } = sequence[i];
+      const code = getKeyCodeForChar(currentChar);
+      const keydownEvent = new KeyboardEvent('keydown', { key: currentChar, code, bubbles: true, cancelable: true });
+      element.dispatchEvent(keydownEvent);
+
+      let beforeInputCancelled = false;
+      if (typeof InputEvent === 'function') {
+        const beforeInput = new InputEvent('beforeinput', { data: currentChar, inputType: 'insertText', bubbles: true, cancelable: true });
+        beforeInputCancelled = !element.dispatchEvent(beforeInput);
+      }
+
+      if (!beforeInputCancelled) {
+        applyValueInsertion(element, currentChar);
+        if (typeof InputEvent === 'function') {
+          element.dispatchEvent(new InputEvent('input', { data: currentChar, inputType: 'insertText', bubbles: true }));
+        } else {
+          element.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      }
+
+      element.dispatchEvent(new KeyboardEvent('keypress', { key: currentChar, code, bubbles: true }));
+      element.dispatchEvent(new KeyboardEvent('keyup', { key: currentChar, code, bubbles: true }));
+
+      if (countsTowardsTotal) {
+        typedCount += 1;
+      }
+
+      if (shouldMistype && i === 0) {
+        const correctionPause = options.correctionDelayMs + Math.random() * options.varianceMs;
+        totalDelay += correctionPause;
+        await wait(correctionPause);
+        await simulateBackspace(element, options);
+      } else {
+        const delay = Math.min(options.maxDelayMs, Math.max(0, randomDelay(options.charDelayMs, options.varianceMs)));
+        totalDelay += delay;
+        await wait(delay);
+      }
     }
 
-    element.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true }));
-    element.dispatchEvent(new Event('input', { bubbles: true }));
-    element.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true }));
-
-    const rawDelay = randomDelay(options.charDelayMs, options.varianceMs);
-    const delay = Math.max(0, Math.min(rawDelay, options.maxDelayMs));
-    totalDelay += delay;
-    typedCount += 1;
-    if (delay > 0) {
-      await wait(delay);
+    if (options.breathEvery > 0 && typedCount > 0 && typedCount % options.breathEvery === 0) {
+      const pause = options.breathDelayMs + Math.random() * options.varianceMs;
+      totalDelay += pause;
+      await wait(pause);
     }
   }
 
-  return { typed: typedCount, totalDelayMs: totalDelay };
+  return { typed: typedCount, totalDelayMs: Math.round(totalDelay) };
 }
 
 export async function humanLikeClick(selector, profile = {}) {
-  const options = { ...defaultClickProfile, ...profile };
+  const { persona, personaId, ...inlineOverrides } = profile || {};
+  const personaKey = personaId || persona;
+  const personaOverrides = personaKey ? personaProfiles.get(String(personaKey))?.click : undefined;
+  const options = mergeProfiles(defaultClickProfile, personaOverrides, inlineOverrides);
   const element = document.querySelector(selector);
   if (!element) {
     throw new Error(`Element not found: ${selector}`);
   }
 
-  element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  element.scrollIntoView({ behavior: 'smooth', block: options.scrollAlignment });
   await wait(options.preMoveDelayMs);
 
   const rect = element.getBoundingClientRect();
-  const x = rect.left + rect.width / 2;
-  const y = rect.top + rect.height / 2;
+  const offsetX = (Math.random() - 0.5) * (options.targetVariancePx ?? 4);
+  const offsetY = (Math.random() - 0.5) * (options.targetVariancePx ?? 4);
+  const targetX = rect.left + rect.width * options.targetXRatio + offsetX;
+  const targetY = rect.top + rect.height * options.targetYRatio + offsetY;
 
-  const eventInit = { view: window, bubbles: true, cancelable: true, clientX: x, clientY: y };
-  element.dispatchEvent(new MouseEvent('mouseenter', eventInit));
-  await wait(options.hoverMs);
-  element.dispatchEvent(new MouseEvent('mouseover', eventInit));
-  await wait(options.hoverMs);
-  element.dispatchEvent(new MouseEvent('mousedown', eventInit));
-  await wait(50);
-  element.dispatchEvent(new MouseEvent('mouseup', eventInit));
-  element.dispatchEvent(new MouseEvent('click', eventInit));
+  await smoothPointerMove(targetX, targetY, {
+    steps: options.pointerSteps,
+    jitterPx: options.pointerJitterPx,
+    durationMs: options.pointerDurationMs,
+    varianceMs: options.pointerVarianceMs
+  });
 
-  return { clicked: true };
+  dispatchPointerFrame('pointerover', pointerState.x, pointerState.y, { pressure: 0.05 }, element);
+  await wait(options.hoverMs);
+  dispatchPointerFrame('pointerenter', pointerState.x, pointerState.y, { pressure: 0.08 }, element);
+  await wait(options.hoverMs / 2);
+
+  dispatchPointerFrame('pointerdown', pointerState.x, pointerState.y, { buttons: 1, pressure: 0.65 }, element);
+  await wait(options.pressDurationMs);
+  dispatchPointerFrame('pointerup', pointerState.x, pointerState.y, { buttons: 0, pressure: 0 }, element);
+
+  element.dispatchEvent(new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    clientX: pointerState.x,
+    clientY: pointerState.y,
+    view: window,
+    detail: 1
+  }));
+
+  await wait(options.releaseDelayMs);
+
+  for (let i = 0; i < (options.microAdjustments ?? 0); i += 1) {
+    const microX = pointerState.x + (Math.random() - 0.5) * 3;
+    const microY = pointerState.y + (Math.random() - 0.5) * 3;
+    dispatchPointerFrame('pointermove', microX, microY, { pressure: 0.02 }, element);
+    await wait(12 + Math.random() * 18);
+  }
+  return { clicked: true, target: selector };
+}
+
+async function performSmoothScroll(distance, options) {
+  const steps = Math.max(1, Math.floor(options.stepCount));
+  const stepDelay = Math.max(8, options.stepDelayMs);
+  const perStep = distance / steps;
+
+  for (let i = 0; i < steps; i += 1) {
+    window.scrollBy({ top: perStep, left: 0, behavior: 'auto' });
+    await wait(stepDelay + Math.random() * 6);
+  }
 }
 
 export async function humanLikeScroll(profile = {}) {
-  const options = { ...defaultScrollProfile, ...profile };
+  const { persona, personaId, ...inlineOverrides } = profile || {};
+  const personaKey = personaId || persona;
+  const personaOverrides = personaKey ? personaProfiles.get(String(personaKey))?.scroll : undefined;
+  const options = mergeProfiles(defaultScrollProfile, personaOverrides, inlineOverrides);
   let total = 0;
+  const directionMultiplier = options.direction === 'up' ? -1 : 1;
 
   for (let i = 0; i < options.chunks; i += 1) {
-    const amount = options.direction === 'up' ? -options.chunkPx : options.chunkPx;
-    window.scrollBy({ top: amount, behavior: 'smooth' });
-    total += Math.abs(amount);
+    const magnitude = options.chunkPx * (0.7 + Math.random() * 0.6);
+    const delta = magnitude * directionMultiplier;
+    await performSmoothScroll(delta, options);
+    total += Math.abs(delta);
     await wait(randomDelay(options.delayMs, options.varianceMs));
   }
 
-  return { scrolledPx: total };
+  return { scrolledPx: Math.round(total) };
 }
 
 export async function humanLikeMouseMove(profile = {}) {
-  const options = { ...defaultMouseProfile, ...profile };
+  const { persona, personaId, ...inlineOverrides } = profile || {};
+  const personaKey = personaId || persona;
+  const personaOverrides = personaKey ? personaProfiles.get(String(personaKey))?.mouse : undefined;
+  const options = mergeProfiles(defaultMouseProfile, personaOverrides, inlineOverrides);
   if (!options.enable) {
     return { moved: false };
   }
 
-  const rawSteps = Number(options.steps);
-  const steps = Number.isFinite(rawSteps) ? Math.max(1, Math.floor(rawSteps)) : Math.max(1, defaultMouseProfile.steps);
-  const waitPerStep = steps > 0 ? options.hoverMs / steps : options.hoverMs;
+  let targetX = options.x;
+  let targetY = options.y;
 
-  for (let i = 0; i < steps; i += 1) {
-    const x = Math.random() * window.innerWidth;
-    const y = Math.random() * window.innerHeight;
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: x, clientY: y, bubbles: true }));
-    if (waitPerStep > 0) {
-      await wait(waitPerStep);
+  if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) {
+    if (options.targetSelector) {
+      const target = document.querySelector(options.targetSelector);
+      if (target) {
+        const rect = target.getBoundingClientRect();
+        targetX = rect.left + rect.width / 2;
+        targetY = rect.top + rect.height / 2;
+      }
     }
   }
 
-  return { moved: true };
+  if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) {
+    targetX = Math.random() * (window.innerWidth || document.documentElement.clientWidth || 1);
+    targetY = Math.random() * (window.innerHeight || document.documentElement.clientHeight || 1);
+  }
+
+  await smoothPointerMove(targetX, targetY, options);
+  return { moved: true, targetX: pointerState.x, targetY: pointerState.y };
+}
+
+function mergeProfiles(...profiles) {
+  const result = {};
+  profiles.filter(Boolean).forEach(profile => {
+    Object.entries(profile).forEach(([key, value]) => {
+      if (value === undefined) {
+        return;
+      }
+
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        result[key] = mergeProfiles(result[key] || {}, value);
+      } else {
+        result[key] = value;
+      }
+    });
+  });
+  return result;
 }

--- a/scripts/utils/dom.js
+++ b/scripts/utils/dom.js
@@ -1,0 +1,233 @@
+const VISIBILITY_THRESHOLD = 0.1;
+const SHADOW_SELECTOR_CACHE = new Map();
+
+export function isVisible(element) {
+  if (!element) {
+    return false;
+  }
+
+  const style = window.getComputedStyle(element);
+  if (!style) {
+    return false;
+  }
+
+  if (style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0) {
+    return false;
+  }
+
+  const rect = element.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    return false;
+  }
+
+  const inViewport =
+    rect.bottom >= 0 &&
+    rect.right >= 0 &&
+    rect.top <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.left <= (window.innerWidth || document.documentElement.clientWidth);
+
+  if (!inViewport) {
+    return false;
+  }
+
+  const area = rect.width * rect.height;
+  const viewportArea = (window.innerWidth || 1) * (window.innerHeight || 1);
+  const areaRatio = area / viewportArea;
+  return areaRatio >= VISIBILITY_THRESHOLD || isElementInteractable(element, rect, style);
+}
+
+export function getVisibilityMetrics(element) {
+  if (!element) {
+    return { visible: false, areaRatio: 0, inViewport: false, rect: null };
+  }
+
+  const rect = element.getBoundingClientRect();
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 1;
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 1;
+  const viewportArea = viewportWidth * viewportHeight;
+  const area = rect.width * rect.height;
+  const inViewport =
+    rect.bottom >= 0 &&
+    rect.right >= 0 &&
+    rect.top <= viewportHeight &&
+    rect.left <= viewportWidth;
+
+  return {
+    visible: isVisible(element),
+    areaRatio: viewportArea === 0 ? 0 : area / viewportArea,
+    inViewport,
+    rect
+  };
+}
+
+export function elementContainsText(element, patterns) {
+  if (!element) {
+    return false;
+  }
+
+  const text = (element.textContent || element.value || '').trim();
+  if (!text) {
+    return false;
+  }
+
+  return patterns.some(pattern => pattern.test(text));
+}
+
+export function collectEvidence(elements) {
+  return elements
+    .filter(Boolean)
+    .map(el => {
+      const metrics = getVisibilityMetrics(el);
+      return {
+        selector: describeElement(el),
+        areaRatio: Number(metrics.areaRatio.toFixed(3)),
+        inViewport: metrics.inViewport,
+        role: getElementRole(el),
+        text: truncateTextContent(el)
+      };
+    });
+}
+
+export function queryDeep(selector, root = document) {
+  if (!selector) {
+    return [];
+  }
+
+  const results = new Set();
+  const stack = [root];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) {
+      continue;
+    }
+
+    if (node instanceof Element || node instanceof Document || node instanceof ShadowRoot) {
+      const scopedSelector = getScopedSelector(selector, node);
+      node.querySelectorAll(scopedSelector).forEach(el => results.add(el));
+
+      node.children?.forEach(child => {
+        if (child.shadowRoot) {
+          stack.push(child.shadowRoot);
+        }
+      });
+    }
+  }
+
+  return Array.from(results);
+}
+
+export function computeOverlayScore(element) {
+  if (!element) {
+    return 0;
+  }
+
+  const metrics = getVisibilityMetrics(element);
+  if (!metrics.visible) {
+    return 0;
+  }
+
+  const style = window.getComputedStyle(element);
+  const zIndex = Number.parseInt(style.zIndex || '0', 10) || 0;
+  const fixedWeight = style.position === 'fixed' || style.position === 'sticky' ? 0.15 : 0;
+  const backdropWeight = style.backdropFilter && style.backdropFilter !== 'none' ? 0.2 : 0;
+  const dimWeight = style.backgroundColor && /rgba\(0, 0, 0, 0\.\d+\)/i.test(style.backgroundColor) ? 0.15 : 0;
+  const areaWeight = Math.min(0.4, metrics.areaRatio * 1.5);
+  const zIndexWeight = Math.min(0.3, Math.max(0, zIndex) / 100);
+  return fixedWeight + backdropWeight + dimWeight + areaWeight + zIndexWeight;
+}
+
+export function getElementRole(element) {
+  if (!(element instanceof Element)) {
+    return undefined;
+  }
+
+  return element.getAttribute('role') || element.getAttribute('aria-role') || element.tagName.toLowerCase();
+}
+
+export function extractTextTokens(element) {
+  if (!element) {
+    return [];
+  }
+
+  const text = (element.textContent || '').trim().toLowerCase();
+  if (!text) {
+    return [];
+  }
+
+  return text.split(/[^a-z0-9]+/i).filter(Boolean);
+}
+
+export function gatherCandidates(selectors, { includeShadowDom = true } = {}) {
+  const elements = new Set();
+  selectors.forEach(selector => {
+    document.querySelectorAll(selector).forEach(el => elements.add(el));
+    if (includeShadowDom) {
+      queryDeep(selector).forEach(el => elements.add(el));
+    }
+  });
+  return Array.from(elements);
+}
+
+function isElementInteractable(element, rect, style) {
+  if (style.pointerEvents === 'none') {
+    return false;
+  }
+
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const topElement = document.elementFromPoint(centerX, centerY);
+  return topElement === element || element.contains(topElement);
+}
+
+function describeElement(element) {
+  if (!(element instanceof Element)) {
+    return 'unknown';
+  }
+
+  const parts = [element.tagName.toLowerCase()];
+  if (element.id) {
+    parts.push(`#${element.id}`);
+  }
+  if (element.classList && element.classList.length > 0) {
+    parts.push(`.${Array.from(element.classList).slice(0, 3).join('.')}`);
+  }
+
+  return parts.join('');
+}
+
+function truncateTextContent(element, maxLength = 80) {
+  const text = (element.textContent || '').trim();
+  if (!text) {
+    return '';
+  }
+
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  return `${text.slice(0, maxLength)}…`;
+}
+
+function getScopedSelector(selector, node) {
+  if (node === document || node === document.documentElement || node === document.body) {
+    return selector;
+  }
+
+  if (!node.host) {
+    return selector;
+  }
+
+  if (SHADOW_SELECTOR_CACHE.has(selector)) {
+    return SHADOW_SELECTOR_CACHE.get(selector);
+  }
+
+  // Prefix :host to preserve context when querying inside a shadow root
+  const scoped = selector
+    .split(',')
+    .map(segment => segment.trim())
+    .filter(Boolean)
+    .map(segment => segment.startsWith(':host') ? segment : `:host ${segment}`)
+    .join(', ');
+  SHADOW_SELECTOR_CACHE.set(selector, scoped);
+  return scoped;
+}

--- a/src/Aura.Orchestrator/Configuration/OrchestratorConfig.cs
+++ b/src/Aura.Orchestrator/Configuration/OrchestratorConfig.cs
@@ -39,6 +39,22 @@ public sealed class SchedulingConfig
     /// Sleep interval between per drone queue scans.
     /// </summary>
     public int DispatchLoopDelayMs { get; set; } = 100;
+
+    /// <summary>
+    /// Maximum number of times a task will be retried when its persona cannot be loaded.
+    /// </summary>
+    public int PersonaMissingMaxRetries { get; set; } = 5;
+
+    /// <summary>
+    /// Base delay in seconds before retrying a task that failed to load a persona.
+    /// Exponential backoff is applied on top of this base value.
+    /// </summary>
+    public int PersonaMissingBaseDelaySec { get; set; } = 5;
+
+    /// <summary>
+    /// Upper bound in seconds for the persona retry backoff delay.
+    /// </summary>
+    public int PersonaMissingMaxBackoffSec { get; set; } = 120;
 }
 
 public sealed class ReadyQueueConfig
@@ -55,6 +71,11 @@ public sealed class LimitsConfig
 {
     public GlobalDomainLimits Global { get; set; } = new();
     public PerDomainLimits PerDomain { get; set; } = new();
+
+    /// <summary>
+    /// Seconds before idle domain limiter state is trimmed from memory.
+    /// </summary>
+    public int DomainStateTtlSeconds { get; set; } = 600;
 }
 
 public sealed class GlobalDomainLimits

--- a/src/Aura.Orchestrator/Interventions/IInterventionNotificationSink.cs
+++ b/src/Aura.Orchestrator/Interventions/IInterventionNotificationSink.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Aura.Orchestrator.Interventions;
+
+public sealed record InterventionNotification(
+    string CommandId,
+    string DroneId,
+    string? Type,
+    string? Reason,
+    DateTime RequestedAtUtc,
+    IReadOnlyDictionary<string, object?>? Metadata);
+
+public interface IInterventionNotificationSink
+{
+    Task NotifyAsync(InterventionNotification notification, CancellationToken cancellationToken = default);
+}

--- a/src/Aura.Orchestrator/Interventions/SignalROperatorNotifier.cs
+++ b/src/Aura.Orchestrator/Interventions/SignalROperatorNotifier.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Aura.Orchestrator.Communication;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+
+namespace Aura.Orchestrator.Interventions;
+
+public sealed class SignalROperatorNotifier : IInterventionNotificationSink
+{
+    private readonly IHubContext<DroneHub> _hubContext;
+    private readonly ILogger<SignalROperatorNotifier> _logger;
+
+    public SignalROperatorNotifier(IHubContext<DroneHub> hubContext, ILogger<SignalROperatorNotifier> logger)
+    {
+        _hubContext = hubContext;
+        _logger = logger;
+    }
+
+    public async Task NotifyAsync(InterventionNotification notification, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _hubContext.Clients.Group("operators").SendAsync(
+                "InterventionRequested",
+                new
+                {
+                    commandId = notification.CommandId,
+                    droneId = notification.DroneId,
+                    type = notification.Type ?? "unknown",
+                    reason = notification.Reason ?? "unspecified",
+                    requestedAtUtc = notification.RequestedAtUtc,
+                    metadata = notification.Metadata
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogDebug(
+                "Skipping operator notification for command {CommandId} due to cancellation",
+                notification.CommandId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to notify operators about intervention for command {CommandId}",
+                notification.CommandId);
+            throw;
+        }
+    }
+}

--- a/src/Aura.Orchestrator/Scheduling/IDeadLetterQueue.cs
+++ b/src/Aura.Orchestrator/Scheduling/IDeadLetterQueue.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Aura.Orchestrator.Scheduling;
+
+public sealed record DeadLetterCommand(
+    string CommandId,
+    string Reason,
+    string? PersonaId,
+    string? DroneId,
+    int RetryCount,
+    DateTime FailedAtUtc,
+    IReadOnlyDictionary<string, object?>? Metadata);
+
+public interface IDeadLetterQueue
+{
+    Task PublishAsync(DeadLetterCommand command, CancellationToken cancellationToken = default);
+}
+
+public sealed class NullDeadLetterQueue : IDeadLetterQueue
+{
+    public static NullDeadLetterQueue Instance { get; } = new();
+
+    private NullDeadLetterQueue()
+    {
+    }
+
+    public Task PublishAsync(DeadLetterCommand command, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Aura.Orchestrator/Scheduling/ScheduledTask.cs
+++ b/src/Aura.Orchestrator/Scheduling/ScheduledTask.cs
@@ -17,6 +17,7 @@ public sealed class ScheduledTask
     public DateTime EnqueuedAt { get; set; } = DateTime.UtcNow;
     public string NodeId { get; set; } = string.Empty;
     public string ProcessId { get; set; } = string.Empty;
+    public int PersonaRetryCount { get; set; }
 }
 
 public enum TaskPriority

--- a/src/Aura.Orchestrator/Security/PublicSuffixList.cs
+++ b/src/Aura.Orchestrator/Security/PublicSuffixList.cs
@@ -4,22 +4,36 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Aura.Orchestrator.Security;
 
 public sealed class PublicSuffixList
 {
+    private readonly ILogger<PublicSuffixList> _logger;
     private readonly HashSet<string> _rules;
     private readonly HashSet<string> _wildcardRules;
     private readonly HashSet<string> _exceptionRules;
 
     public PublicSuffixList()
-        : this(LoadEmbeddedRules())
+        : this(NullLogger<PublicSuffixList>.Instance)
+    {
+    }
+
+    public PublicSuffixList(ILogger<PublicSuffixList> logger)
+        : this(logger, LoadEmbeddedRules(logger))
     {
     }
 
     public PublicSuffixList(IEnumerable<string> rules)
+        : this(NullLogger<PublicSuffixList>.Instance, rules)
     {
+    }
+
+    public PublicSuffixList(ILogger<PublicSuffixList> logger, IEnumerable<string> rules)
+    {
+        _logger = logger ?? NullLogger<PublicSuffixList>.Instance;
         _rules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _wildcardRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         _exceptionRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -43,6 +57,15 @@ public sealed class PublicSuffixList
             else
             {
                 _rules.Add(rule);
+            }
+        }
+
+        if (_rules.Count == 0 && _wildcardRules.Count == 0 && _exceptionRules.Count == 0)
+        {
+            _logger.LogWarning("Public suffix list initialised with zero entries; applying default fallback rules.");
+            foreach (var fallback in DefaultRules())
+            {
+                _rules.Add(fallback);
             }
         }
     }
@@ -153,13 +176,19 @@ public sealed class PublicSuffixList
         return null;
     }
 
-    private static IEnumerable<string> LoadEmbeddedRules()
+    private static IEnumerable<string> LoadEmbeddedRules(ILogger<PublicSuffixList> logger)
     {
+        if (TryLoadExternalRules(logger, out var externalRules))
+        {
+            return externalRules;
+        }
+
         var assembly = Assembly.GetExecutingAssembly();
         var resourceName = "Aura.Orchestrator.Security.public_suffix_list.dat";
         using var stream = assembly.GetManifestResourceStream(resourceName);
         if (stream == null)
         {
+            logger.LogCritical("Embedded public suffix list resource was not found; configure PUBLIC_SUFFIX_LIST_PATH to restore full coverage.");
             return DefaultRules();
         }
 
@@ -174,7 +203,59 @@ public sealed class PublicSuffixList
             }
         }
 
+        if (lines.Count < 100)
+        {
+            logger.LogCritical("Embedded public suffix list contained only {Count} entries; configure an external dataset for accuracy.", lines.Count);
+            return DefaultRules();
+        }
+
         return lines;
+    }
+
+    private static bool TryLoadExternalRules(ILogger<PublicSuffixList> logger, out IEnumerable<string> rules)
+    {
+        var candidates = new List<string>();
+        var envPath = Environment.GetEnvironmentVariable("PUBLIC_SUFFIX_LIST_PATH");
+        if (!string.IsNullOrWhiteSpace(envPath))
+        {
+            candidates.Add(envPath);
+        }
+
+        var baseDir = AppContext.BaseDirectory;
+        candidates.Add(Path.Combine(baseDir, "public_suffix_list.dat"));
+        candidates.Add(Path.Combine(baseDir, "data", "public_suffix_list.dat"));
+
+        foreach (var candidate in candidates.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            try
+            {
+                if (!File.Exists(candidate))
+                {
+                    continue;
+                }
+
+                var lines = File.ReadAllLines(candidate)
+                    .Where(line => !string.IsNullOrWhiteSpace(line))
+                    .ToList();
+
+                if (lines.Count < 100)
+                {
+                    logger.LogWarning("Public suffix dataset at {Path} looked invalid (only {Count} entries)", candidate, lines.Count);
+                    continue;
+                }
+
+                logger.LogInformation("Loaded public suffix list from external path {Path}", candidate);
+                rules = lines;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to load public suffix list from {Path}", candidate);
+            }
+        }
+
+        rules = Array.Empty<string>();
+        return false;
     }
 
     private static IEnumerable<string> DefaultRules()

--- a/src/Aura.Orchestrator/Services/ResultPersistenceQueue.cs
+++ b/src/Aura.Orchestrator/Services/ResultPersistenceQueue.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Aura.Orchestrator.Communication;
+using Aura.Orchestrator.Configuration;
+using Aura.Orchestrator.Metrics;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+
+namespace Aura.Orchestrator.Services;
+
+public sealed record ResultPersistenceRequest(
+    string CommandId,
+    IReadOnlyList<ArtifactData> Artifacts,
+    string? SessionLeaseId,
+    JObject? SessionState);
+
+public interface IResultPersistenceQueue
+{
+    ValueTask QueueAsync(ResultPersistenceRequest request, CancellationToken cancellationToken = default);
+}
+
+public sealed class ResultPersistenceQueue : BackgroundService, IResultPersistenceQueue
+{
+    private const int DefaultCapacity = 256;
+
+    private readonly Channel<ResultPersistenceRequest> _queue;
+    private readonly ISharedContextStore _sharedContextStore;
+    private readonly ISessionRegistry _sessionRegistry;
+    private readonly IMetricsCollector _metrics;
+    private readonly ILogger<ResultPersistenceQueue> _logger;
+
+    public ResultPersistenceQueue(
+        ISharedContextStore sharedContextStore,
+        ISessionRegistry sessionRegistry,
+        IMetricsCollector metrics,
+        IOptions<OrchestratorConfig> options,
+        ILogger<ResultPersistenceQueue> logger)
+    {
+        _sharedContextStore = sharedContextStore;
+        _sessionRegistry = sessionRegistry;
+        _metrics = metrics;
+        _logger = logger;
+
+        var configuredCapacity = Math.Max(DefaultCapacity, options.Value.Scheduling?.ReadyQueue?.Capacity ?? DefaultCapacity);
+        var channelOptions = new BoundedChannelOptions(configuredCapacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait,
+            SingleReader = true,
+            SingleWriter = false
+        };
+
+        _queue = Channel.CreateBounded<ResultPersistenceRequest>(channelOptions);
+    }
+
+    public ValueTask QueueAsync(ResultPersistenceRequest request, CancellationToken cancellationToken = default)
+    {
+        if (_queue.Writer.TryWrite(request))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return _queue.Writer.WriteAsync(request, cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var workItem in _queue.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+        {
+            await ProcessAsync(workItem, stoppingToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ProcessAsync(ResultPersistenceRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Artifacts.Count > 0)
+        {
+            foreach (var artifact in request.Artifacts)
+            {
+                var artifactType = string.IsNullOrWhiteSpace(artifact.Type) ? "unknown" : artifact.Type;
+                try
+                {
+                    switch (artifact.Type?.ToLowerInvariant())
+                    {
+                        case "facts" when artifact.Data is JArray facts:
+                            await _sharedContextStore.StoreFactsAsync(facts, cancellationToken).ConfigureAwait(false);
+                            break;
+                        case "snippets" when artifact.Data is JArray snippets:
+                            await _sharedContextStore.StoreSnippetsAsync(snippets, cancellationToken).ConfigureAwait(false);
+                            break;
+                        default:
+                            await _sharedContextStore.StoreArtifactAsync(artifact, cancellationToken).ConfigureAwait(false);
+                            break;
+                    }
+
+                    _metrics.IncrementCounter(
+                        "artifacts_persisted_total",
+                        1,
+                        new Dictionary<string, string> { ["type"] = artifactType });
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogDebug(
+                        "Artifact persistence for command {CommandId} canceled during shutdown",
+                        request.CommandId);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Failed to persist artifact {ArtifactType} for command {CommandId}",
+                        artifactType,
+                        request.CommandId);
+                    _metrics.IncrementCounter(
+                        "artifacts_persist_failed_total",
+                        1,
+                        new Dictionary<string, string> { ["type"] = artifactType });
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SessionLeaseId) && request.SessionState is JObject state)
+        {
+            try
+            {
+                await _sessionRegistry.UpdateSessionStateAsync(request.SessionLeaseId!, state, cancellationToken).ConfigureAwait(false);
+                _metrics.IncrementCounter("session_state_persisted_total");
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogDebug(
+                    "Session state persistence for command {CommandId} canceled during shutdown",
+                    request.CommandId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to persist session state for lease {LeaseId} from command {CommandId}",
+                    request.SessionLeaseId,
+                    request.CommandId);
+                _metrics.IncrementCounter("session_state_persist_failed_total");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prioritize scheduler intake with a bounded priority queue, restartable per-drone processors, and persona retry handling that escalates to intervention and dead-letter sinks instead of dropping work
- offload artifact and session persistence to a background queue so hub threads stay responsive while recording success/failure metrics
- emit limiter throttle counters, harden public-suffix loading, and expand browser automation heuristics for consent/login/captcha along with persona-aware human-like actions

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ca47f3b9748320b0b9e8cf5a25f87d